### PR TITLE
Prevent LAContext evaluatePolicy:localizedReason:reply: from being invoked multiple times

### DIFF
--- a/VENTouchLock/VENTouchLock.h
+++ b/VENTouchLock/VENTouchLock.h
@@ -9,6 +9,7 @@ typedef NS_ENUM(NSUInteger, VENTouchLockTouchIDResponse) {
     VENTouchLockTouchIDResponseSuccess,
     VENTouchLockTouchIDResponseUsePasscode,
     VENTouchLockTouchIDResponseCanceled,
+    VENTouchLockTouchIDResponsePromptAlreadyPresent,
 };
 
 @interface VENTouchLock : NSObject

--- a/VENTouchLock/VENTouchLock.m
+++ b/VENTouchLock/VENTouchLock.m
@@ -127,12 +127,15 @@ static NSString *const VENTouchLockUserDefaultsKeyTouchIDActivated = @"VENTouchL
 
 - (void)requestTouchIDWithCompletion:(void (^)(VENTouchLockTouchIDResponse))completionBlock reason:(NSString *)reason
 {
-    if ([[self class] canUseTouchID]) {
+    static BOOL isTouchIDPresented = NO;
+    if ([[self class] canUseTouchID] && !isTouchIDPresented) {
+        isTouchIDPresented = YES;
         LAContext *context = [[LAContext alloc] init];
         context.localizedFallbackTitle = NSLocalizedString(@"Enter Passcode", nil);
         [context evaluatePolicy:LAPolicyDeviceOwnerAuthenticationWithBiometrics
                 localizedReason:reason
                           reply:^(BOOL success, NSError *error) {
+                              isTouchIDPresented = NO;
                               dispatch_async(dispatch_get_main_queue(), ^{
                                   if (success) {
                                       if (completionBlock) {


### PR DESCRIPTION
This seems to be causing the freeze in #24 . A race condition exists where ```showUnlockAnimated``` can be called more than once probably due to an inconsistent way in which Apple calls view controller lifecycle methods for a view controller that is being presented while the app is backgrounding/foregrounding.

This leads ```LAContext -evaluatePolicy:localizedReason:reply:``` being called while one is already presenting, which leads to some sort of deadlock.

This PR prevents multiple calls to ```evaluatePolicy:localizedReason:reply:``` to avoid the deadlock.