### PR TITLE
respect appearance settings

### DIFF
--- a/VENTouchLock/Controllers/VENTouchLockSplashViewController.m
+++ b/VENTouchLock/Controllers/VENTouchLockSplashViewController.m
@@ -100,9 +100,14 @@
 
 - (void)showPasscodeAnimated:(BOOL)animated
 {
-    [self presentViewController:[[self enterPasscodeVC] embeddedInNavigationController]
-                                            animated:animated
-                                          completion:nil];
+    VENTouchLockEnterPasscodeViewController *enterPassCodeViewController;
+    if (self.touchLock.appearance.splashShouldEmbedInNavigationController) {
+        enterPassCodeViewController = [[self enterPasscodeVC] embeddedInNavigationController];
+    } else {
+        enterPassCodeViewController = [self enterPasscodeVC];
+    }
+
+    [self presentViewController:enterPassCodeViewController animated:animated completion:nil];
 }
 
 - (VENTouchLockEnterPasscodeViewController *)enterPasscodeVC

--- a/VENTouchLock/Controllers/VENTouchLockSplashViewController.m
+++ b/VENTouchLock/Controllers/VENTouchLockSplashViewController.m
@@ -100,8 +100,8 @@
 
 - (void)showPasscodeAnimated:(BOOL)animated
 {
-    VENTouchLockEnterPasscodeViewController *enterPassCodeViewController;
-    if (self.touchLock.appearance.splashShouldEmbedInNavigationController) {
+    UIViewController *enterPassCodeViewController;
+    if (self.touchLock.appearance.passcodeViewControllerShouldEmbedInNavigationController) {
         enterPassCodeViewController = [[self enterPasscodeVC] embeddedInNavigationController];
     } else {
         enterPassCodeViewController = [self enterPasscodeVC];

--- a/VENTouchLock/Models/VENTouchLockAppearance.h
+++ b/VENTouchLock/Models/VENTouchLockAppearance.h
@@ -10,6 +10,7 @@
 @property (strong, nonatomic) UIColor *passcodeViewControllerTitleColor;
 @property (strong, nonatomic) UIColor *passcodeViewControllerCharacterColor;
 @property (strong, nonatomic) UIColor *passcodeViewControllerBackgroundColor;
+@property (assign, nonatomic) BOOL passcodeViewControllerShouldEmbedInNavigationController;
 @property (strong, nonatomic) NSString *cancelBarButtonItemTitle;
 
 /**-----------------------------------------------------------------------------
@@ -20,7 +21,6 @@
 @property (strong, nonatomic) NSString *createPasscodeConfirmLabelText;
 @property (strong, nonatomic) NSString *createPasscodeMismatchedLabelText;
 @property (strong, nonatomic) NSString *createPasscodeViewControllerTitle;
-
 
 /**-----------------------------------------------------------------------------
  * @description Enter Passcode View Controller Preferences

--- a/VENTouchLock/Models/VENTouchLockAppearance.m
+++ b/VENTouchLock/Models/VENTouchLockAppearance.m
@@ -9,6 +9,7 @@
         _passcodeViewControllerTitleColor = [UIColor blackColor];
         _passcodeViewControllerCharacterColor = [UIColor blackColor];
         _passcodeViewControllerBackgroundColor = [UIColor colorWithRed:239/255.0f green:239/255.0f blue:244/255.0f alpha:1.0f];
+        _passcodeViewControllerShouldEmbedInNavigationController = NO;
         _cancelBarButtonItemTitle = NSLocalizedString(@"Cancel", nil);
         _createPasscodeInitialLabelText = NSLocalizedString(@"Enter a new passcode", nil);
         _createPasscodeConfirmLabelText = NSLocalizedString(@"Please re-enter your passcode", nil);


### PR DESCRIPTION
When `VENTouchLockSplashViewController` subclass sets `self.touchLock.appearance.splashShouldEmbedInNavigationController = NO;` (default is also `NO`.)  During unlocking, a user chooses `Enter Passcode`, the enter passcode view controller should not be embedded. 