### PR TITLE
use passcode after pressing  on TouchLock

### DIFF
--- a/VENTouchLock/Models/VENTouchLockAppearance.h
+++ b/VENTouchLock/Models/VENTouchLockAppearance.h
@@ -37,4 +37,11 @@
  */
 @property (assign, nonatomic) BOOL splashShouldEmbedInNavigationController;
 
+/**-----------------------------------------------------------------------------
+ * @description Touch ID Prompt Preferences
+ * -----------------------------------------------------------------------------
+ */
+
+@property (assign, nonatomic) BOOL touchIDCancelPresentsPasscodeViewController;
+
 @end

--- a/VENTouchLock/Models/VENTouchLockAppearance.m
+++ b/VENTouchLock/Models/VENTouchLockAppearance.m
@@ -19,6 +19,7 @@
         _enterPasscodeIncorrectLabelText = NSLocalizedString(@"Incorrect passcode. Try again.", nil);
         _enterPasscodeViewControllerTitle = NSLocalizedString(@"Enter Passcode", nil);
         _splashShouldEmbedInNavigationController = NO;
+        _touchIDCancelPresentsPasscodeViewController = NO;
     }
     return self;
 }

--- a/VENTouchLock/VENTouchLock.m
+++ b/VENTouchLock/VENTouchLock.m
@@ -149,8 +149,9 @@ static NSString *const VENTouchLockUserDefaultsKeyTouchIDActivated = @"VENTouchL
                                               case LAErrorUserFallback:
                                                   response = VENTouchLockTouchIDResponseUsePasscode;
                                                   break;
+                                              case LAErrorAuthenticationFailed: // when TouchID max retry is reached, fallbacks to passcode
                                               case LAErrorUserCancel:
-                                                  response = VENTouchLockTouchIDResponseCanceled;
+                                                  response = (self.appearance.touchIDCancelPresentsPasscodeViewController) ? VENTouchLockTouchIDResponseUsePasscode : VENTouchLockTouchIDResponseCanceled;
                                                   break;
                                               default:
                                                   response = VENTouchLockTouchIDResponseUndefined;


### PR DESCRIPTION
This offers the option to only use `passcode` for both `Enter Passcode` and `Cancel`, instead of implementing a chooser on the splash screen like the example app.