### PR TITLE
Remove references to mainBundle

### DIFF
--- a/VENTouchLock/Views/VENTouchLockPasscodeView.m
+++ b/VENTouchLock/Views/VENTouchLockPasscodeView.m
@@ -16,7 +16,7 @@
 
 - (instancetype)initWithTitle:(NSString *)title frame:(CGRect)frame titleColor:(UIColor *)titleColor characterColor:(UIColor *)characterColor
 {
-    NSArray *nibArray = [[NSBundle mainBundle] loadNibNamed:NSStringFromClass([self class])
+    NSArray *nibArray = [[NSBundle bundleForClass:[self class]] loadNibNamed:NSStringFromClass([self class])
                                                       owner:self options:nil];
     self = [nibArray firstObject];
     if (self) {


### PR DESCRIPTION
Figured out the issue for #42. CocoaPods 0.36.* uses frameworks, so [NSBundle mainBundle] needs to be replaced with [NSBundle bundleForClass:]

(+ @vandyshev)