### PR TITLE
Expose lock method

### DIFF
--- a/VENTouchLock/VENTouchLock.h
+++ b/VENTouchLock/VENTouchLock.h
@@ -94,6 +94,12 @@ typedef NS_ENUM(NSUInteger, VENTouchLockTouchIDResponse) {
 - (NSUInteger)passcodeAttemptLimit;
 
 /**
+ If a passcode is set, calling this method will lock the app. Otherwise, calling it will not do anything.
+ @note The app is automatically locked when on launch and on entering background. Use this method only if necessary in other circumstances.
+ */
+- (void)lock;
+
+/**
  @return The proxy for the receiver's user interface. Custom appearance preferences may optionally be set by editing the returned instance's properties.
  */
 - (VENTouchLockAppearance *)appearance;

--- a/VENTouchLock/VENTouchLock.m
+++ b/VENTouchLock/VENTouchLock.m
@@ -172,8 +172,12 @@ static NSString *const VENTouchLockUserDefaultsKeyTouchIDActivated = @"VENTouchL
     }
 }
 
-- (void)lockFromBackground:(BOOL)fromBackground
+- (void)lock
 {
+    if (![self isPasscodeSet]) {
+        return;
+    }
+
     if (self.splashViewControllerClass != NULL) {
         VENTouchLockSplashViewController *splashViewController = [[self.splashViewControllerClass alloc] init];
         if ([splashViewController isKindOfClass:[VENTouchLockSplashViewController class]]) {
@@ -187,6 +191,7 @@ static NSString *const VENTouchLockUserDefaultsKeyTouchIDActivated = @"VENTouchL
                 displayController = splashViewController;
             }
 
+            BOOL fromBackground = [UIApplication sharedApplication].applicationState != UIApplicationStateBackground;
             if (fromBackground) {
                 [[NSRunLoop currentRunLoop] runMode:NSDefaultRunLoopMode beforeDate:[NSDate dateWithTimeIntervalSinceNow:0.1]];
                 VENTouchLockSplashViewController *snapshotSplashViewController = [[self.splashViewControllerClass alloc] init];
@@ -217,15 +222,13 @@ static NSString *const VENTouchLockUserDefaultsKeyTouchIDActivated = @"VENTouchL
 
 - (void)applicationDidFinishLaunching:(NSNotification *)notification
 {
-    if ([self isPasscodeSet]) {
-        [self lockFromBackground:NO];
-    }
+    [self lock];
 }
 
 - (void)applicationDidEnterBackground:(NSNotification *)notification
 {
-    if ([self isPasscodeSet] && !self.backgroundLockVisible) {
-        [self lockFromBackground:YES];
+    if (!self.backgroundLockVisible) {
+        [self lock];
     }
 }
 

--- a/VENTouchLockSample/Podfile
+++ b/VENTouchLockSample/Podfile
@@ -5,6 +5,6 @@ target "VENTouchLockSample" do
 end
 
 target "VENTouchLockSampleTests" do
-  pod 'KIF', '~> 3.0.8'
+  pod 'KIF', '~> 3.0'
   pod 'FBSnapshotTestCase', '1.4'
 end

--- a/VENTouchLockSample/Podfile.lock
+++ b/VENTouchLockSample/Podfile.lock
@@ -1,18 +1,18 @@
 PODS:
   - FBSnapshotTestCase (1.4)
-  - KIF (3.0.8):
-    - KIF/XCTest (= 3.0.8)
-  - KIF/XCTest (3.0.8)
+  - KIF (3.2.2):
+    - KIF/XCTest (= 3.2.2)
+  - KIF/XCTest (3.2.2)
   - SSKeychain (1.2.2)
 
 DEPENDENCIES:
   - FBSnapshotTestCase (= 1.4)
-  - KIF (~> 3.0.8)
+  - KIF (~> 3.0)
   - SSKeychain (~> 1.2.2)
 
 SPEC CHECKSUMS:
-  FBSnapshotTestCase: f9f225b5ba11c8d8c09075590490df16314e4d62
-  KIF: 2db5e8cf59136dd1267d49cca0d55883389b09d3
-  SSKeychain: cc48bd3ad24fcd9125adb9e0d23dd50b8bbd08b9
+  FBSnapshotTestCase: 892508495a69e8703bab36c9da7674ff740d41db
+  KIF: b0bd762b0c7890b04920cf618021d6d4fd5127bd
+  SSKeychain: 88767e903ee8d274ed380e364d96b7a101235286
 
-COCOAPODS: 0.35.0
+COCOAPODS: 0.36.4

--- a/VENTouchLockSample/VENTouchLockSampleTests/VENTouchLockAutoLockTests.m
+++ b/VENTouchLockSample/VENTouchLockSampleTests/VENTouchLockAutoLockTests.m
@@ -21,17 +21,19 @@
     [self dismissAndResetLock];
     VENTouchLockAppearance *currentAppearance = [VENTouchLock sharedInstance].appearance;
     [tester tapViewWithAccessibilityLabel:@"Set Passcode"];
-    [tester waitForKeyboard];
+    [tester waitForSoftwareKeyboard];
+    [tester waitForTimeInterval:0.5];
     [tester enterTextIntoCurrentFirstResponder:@"1"];
     [tester enterTextIntoCurrentFirstResponder:@"2"];
     [tester enterTextIntoCurrentFirstResponder:@"3"];
     [tester enterTextIntoCurrentFirstResponder:@"4"];
     [tester waitForViewWithAccessibilityLabel:currentAppearance.createPasscodeConfirmLabelText];
+    [tester waitForTimeInterval:0.5];
     [tester enterTextIntoCurrentFirstResponder:@"1"];
     [tester enterTextIntoCurrentFirstResponder:@"2"];
     [tester enterTextIntoCurrentFirstResponder:@"3"];
     [tester enterTextIntoCurrentFirstResponder:@"4"];
-    [tester waitForAbsenceOfKeyboard];
+    [tester waitForAbsenceOfSoftwareKeyboard];
 }
 
 - (void)testBasicEnterPasscodeFlow
@@ -39,12 +41,13 @@
     [self dismissAndResetLock];
     [[VENTouchLock sharedInstance] setPasscode:@"7890"];
     [tester tapViewWithAccessibilityLabel:@"Show Passcode"];
-    [tester waitForKeyboard];
+    [tester waitForSoftwareKeyboard];
+    [tester waitForTimeInterval:0.5];
     [tester enterTextIntoCurrentFirstResponder:@"7"];
     [tester enterTextIntoCurrentFirstResponder:@"8"];
     [tester enterTextIntoCurrentFirstResponder:@"9"];
     [tester enterTextIntoCurrentFirstResponder:@"0"];
-    [tester waitForAbsenceOfKeyboard];
+    [tester waitForAbsenceOfSoftwareKeyboard];
 }
 
 - (void)testAdvancedCreatePasscodeFlow
@@ -52,27 +55,31 @@
     [self dismissAndResetLock];
     VENTouchLockAppearance *currentAppearance = [VENTouchLock sharedInstance].appearance;
     [tester tapViewWithAccessibilityLabel:@"Set Passcode"];
-    [tester waitForKeyboard];
+    [tester waitForSoftwareKeyboard];
+    [tester waitForTimeInterval:0.5];
     [tester enterTextIntoCurrentFirstResponder:@"1"];
     [tester enterTextIntoCurrentFirstResponder:@"2"];
     [tester enterTextIntoCurrentFirstResponder:@"3"];
     [tester enterTextIntoCurrentFirstResponder:@"4"];
     [tester waitForViewWithAccessibilityLabel:currentAppearance.createPasscodeConfirmLabelText];
+    [tester waitForTimeInterval:0.5];
     [tester enterTextIntoCurrentFirstResponder:@"1"];
     [tester enterTextIntoCurrentFirstResponder:@"2"];
     [tester enterTextIntoCurrentFirstResponder:@"3"];
     [tester enterTextIntoCurrentFirstResponder:@"1"];
     [tester waitForViewWithAccessibilityLabel:currentAppearance.createPasscodeMismatchedLabelText];
+    [tester waitForTimeInterval:0.5];
     [tester enterTextIntoCurrentFirstResponder:@"1"];
     [tester enterTextIntoCurrentFirstResponder:@"2"];
     [tester enterTextIntoCurrentFirstResponder:@"3"];
     [tester enterTextIntoCurrentFirstResponder:@"4"];
     [tester waitForViewWithAccessibilityLabel:currentAppearance.createPasscodeConfirmLabelText];
+    [tester waitForTimeInterval:0.5];
     [tester enterTextIntoCurrentFirstResponder:@"1"];
     [tester enterTextIntoCurrentFirstResponder:@"2"];
     [tester enterTextIntoCurrentFirstResponder:@"3"];
     [tester enterTextIntoCurrentFirstResponder:@"4"];
-    [tester waitForAbsenceOfKeyboard];
+    [tester waitForAbsenceOfSoftwareKeyboard];
 }
 
 - (void)testAdvancedEnterPasscodeFlow
@@ -81,17 +88,19 @@
     VENTouchLockAppearance *currentAppearance = [VENTouchLock sharedInstance].appearance;
     [[VENTouchLock sharedInstance] setPasscode:@"7890"];
     [tester tapViewWithAccessibilityLabel:@"Show Passcode"];
-    [tester waitForKeyboard];
+    [tester waitForSoftwareKeyboard];
+    [tester waitForTimeInterval:0.5];
     [tester enterTextIntoCurrentFirstResponder:@"7"];
     [tester enterTextIntoCurrentFirstResponder:@"8"];
     [tester enterTextIntoCurrentFirstResponder:@"9"];
     [tester enterTextIntoCurrentFirstResponder:@"9"];
     [tester waitForViewWithAccessibilityLabel:currentAppearance.enterPasscodeIncorrectLabelText];
+    [tester waitForTimeInterval:0.5];
     [tester enterTextIntoCurrentFirstResponder:@"7"];
     [tester enterTextIntoCurrentFirstResponder:@"8"];
     [tester enterTextIntoCurrentFirstResponder:@"9"];
     [tester enterTextIntoCurrentFirstResponder:@"0"];
-    [tester waitForAbsenceOfKeyboard];
+    [tester waitForAbsenceOfSoftwareKeyboard];
 }
 
 - (void)testEnterPasscodeAttemptLimitExceeded
@@ -106,7 +115,7 @@
     VENTouchLockAppearance *currentAppearance = [VENTouchLock sharedInstance].appearance;
     [[VENTouchLock sharedInstance] setPasscode:@"4567"];
     [self simulateAppBackgroundThenForeground];
-    [tester waitForKeyboard];
+    [tester waitForSoftwareKeyboard];
     for (NSUInteger i = 0 ; i < [VENTouchLock sharedInstance].passcodeAttemptLimit; i++) {
         if (i == 0) {
             [tester waitForViewWithAccessibilityLabel:currentAppearance.enterPasscodeInitialLabelText];
@@ -114,13 +123,14 @@
         else {
             [tester waitForViewWithAccessibilityLabel:currentAppearance.enterPasscodeIncorrectLabelText];
         }
+        [tester waitForTimeInterval:0.5];
         [tester enterTextIntoCurrentFirstResponder:@"5"];
         [tester enterTextIntoCurrentFirstResponder:@"5"];
         [tester enterTextIntoCurrentFirstResponder:@"5"];
         [tester enterTextIntoCurrentFirstResponder:@"5"];
         [tester waitForTimeInterval:1.0];
     }
-    [tester waitForAbsenceOfKeyboard];
+    [tester waitForAbsenceOfSoftwareKeyboard];
     [tester waitForViewWithAccessibilityLabel:@"Limit Exceeded"];
     [tester tapViewWithAccessibilityLabel:@"OK"];
 }


### PR DESCRIPTION
This exposes the lock method incase locking the must be called manually.

Also,
This updates KIF (and uses new methods since the old ones don't work and are deprecated) so that it's compatible with Xcode 6.3

- [x] @soffes 
- [x] @hyperspacemark 