### PR TITLE
Make Splash Screen Optional

### DIFF
--- a/VENTouchLock/Controllers/VENTouchLockPasscodeViewController.h
+++ b/VENTouchLock/Controllers/VENTouchLockPasscodeViewController.h
@@ -11,7 +11,7 @@
 
 /**
  This block is called directly before the passcode view controller has completed its intended operation. If the operation was completed successfully, the returned BOOL will return YES, and NO otherwise.
- If this block is defined, it is responsible for dismissing the passcode view controller.
+ If this block is defined, it is responsible for dismissing the passcode view controller and calling the dismissWithResult.
  If this block is nil, the payment view controller will dismiss itself.
  */
 @property (nonatomic, copy) void (^willFinishWithResult)(BOOL success);

--- a/VENTouchLock/Controllers/VENTouchLockPasscodeViewController.h
+++ b/VENTouchLock/Controllers/VENTouchLockPasscodeViewController.h
@@ -5,16 +5,6 @@
 @interface VENTouchLockPasscodeViewController : UIViewController
 
 /**
- @return A TouchLockPasscodeViewController instance
-*/
-- (instancetype)init;
-
-/**
- @return A TouchLockPasscodeViewController instance that reads or writes properties to the TouchLock instance with the given unique identifer
- */
-- (instancetype)initWithTouchLockIdentifier:(NSString *)identifier;
-
-/**
  The initial passcode view attached to this view controller.
  */
 @property (strong, nonatomic) VENTouchLockPasscodeView *passcodeView;
@@ -27,9 +17,14 @@
 @property (nonatomic, copy) void (^willFinishWithResult)(BOOL success);
 
 /**
- The VENTouchLock framework this class interacts with. This property should not be set outside of VENTouchLock framework's automated tests.  By default, it is set to the [VENTouchLock sharedInstance] singleton on initialization.
+ @return A TouchLockPasscodeViewController instance.
  */
-@property (nonatomic, strong) VENTouchLock *touchLock;
+- (instancetype)init;
+
+/**
+ @return A TouchLockPasscodeViewController instance that interacts with the the passed TouchLock.
+ */
+- (instancetype)initWithTouchLock:(VENTouchLock *)touchLock;
 
 /**
  Encapsulates the view controller in a navigation controller.

--- a/VENTouchLock/Controllers/VENTouchLockPasscodeViewController.h
+++ b/VENTouchLock/Controllers/VENTouchLockPasscodeViewController.h
@@ -10,14 +10,18 @@
 @property (strong, nonatomic) VENTouchLockPasscodeView *passcodeView;
 
 /**
- This block is called directly before the passcode view controller has completed its intended operation. If the operation was completed successfully, the returned BOOL will return YES, and NO otherwise.
- If this block is defined, it is responsible for dismissing the passcode view controller and calling the dismissWithResult.
+ This block is called directly before the passcode view controller has completed its intended operation. If the operation was
+ completed successfully, the returned BOOL will return YES, and NO otherwise.
+ If this block is defined, it is responsible for dismissing the passcode view controller and calling the dismissWithResult block.
  If this block is nil, the payment view controller will dismiss itself.
  */
 @property (nonatomic, copy) void (^willFinishWithResult)(BOOL success);
 
 @property (nonatomic, copy) void (^didFinishWithResult)(BOOL success);
 
+/**
+ The TouchLock instance that corresponds to this view controller.
+ */
 @property (nonatomic, weak, readonly) VENTouchLock *touchLock;
 
 /**
@@ -26,7 +30,7 @@
 - (instancetype)init;
 
 /**
- @return A TouchLockPasscodeViewController instance that interacts with the the passed TouchLock.
+ @return A TouchLockPasscodeViewController instance that corresponds with the the passed TouchLock.
  */
 - (instancetype)initWithTouchLock:(VENTouchLock *)touchLock;
 

--- a/VENTouchLock/Controllers/VENTouchLockPasscodeViewController.h
+++ b/VENTouchLock/Controllers/VENTouchLockPasscodeViewController.h
@@ -16,7 +16,9 @@
  */
 @property (nonatomic, copy) void (^willFinishWithResult)(BOOL success);
 
-@property (nonatomic, strong, readonly) VENTouchLock *touchLock;
+@property (nonatomic, copy) void (^didFinishWithResult)(BOOL success);
+
+@property (nonatomic, weak, readonly) VENTouchLock *touchLock;
 
 /**
  @return A TouchLockPasscodeViewController instance.

--- a/VENTouchLock/Controllers/VENTouchLockPasscodeViewController.h
+++ b/VENTouchLock/Controllers/VENTouchLockPasscodeViewController.h
@@ -16,6 +16,8 @@
  */
 @property (nonatomic, copy) void (^willFinishWithResult)(BOOL success);
 
+@property (nonatomic, strong, readonly) VENTouchLock *touchLock;
+
 /**
  @return A TouchLockPasscodeViewController instance.
  */

--- a/VENTouchLock/Controllers/VENTouchLockPasscodeViewController.m
+++ b/VENTouchLock/Controllers/VENTouchLockPasscodeViewController.m
@@ -8,6 +8,7 @@ static const NSInteger VENTouchLockViewControllerPasscodeLength = 4;
 
 @interface VENTouchLockPasscodeViewController () <UITextFieldDelegate>
 
+@property (nonatomic, strong) VENTouchLock *touchLock;
 @property (strong, nonatomic) UITextField *invisiblePasscodeField;
 @property (assign, nonatomic) BOOL shouldIgnoreTextFieldDelegateCalls;
 
@@ -22,14 +23,14 @@ static const NSInteger VENTouchLockViewControllerPasscodeLength = 4;
 
 - (instancetype)init
 {
-    return [self initWithTouchLockIdentifier:nil];
+    return [self initWithTouchLock:[VENTouchLock sharedInstance]];
 }
 
-- (instancetype)initWithTouchLockIdentifier:(NSString *)identifier
+- (instancetype)initWithTouchLock:(VENTouchLock *)touchLock
 {
     self = [super init];
     if (self) {
-        _touchLock = [VENTouchLock sharedInstanceWithTouchLockIdentfier:identifier];
+        _touchLock = touchLock;
     }
     return self;
 }

--- a/VENTouchLock/Controllers/VENTouchLockPasscodeViewController.m
+++ b/VENTouchLock/Controllers/VENTouchLockPasscodeViewController.m
@@ -8,7 +8,7 @@ static const NSInteger VENTouchLockViewControllerPasscodeLength = 4;
 
 @interface VENTouchLockPasscodeViewController () <UITextFieldDelegate>
 
-@property (nonatomic, strong) VENTouchLock *touchLock;
+@property (nonatomic, weak) VENTouchLock *touchLock;
 @property (strong, nonatomic) UITextField *invisiblePasscodeField;
 @property (assign, nonatomic) BOOL shouldIgnoreTextFieldDelegateCalls;
 

--- a/VENTouchLock/Controllers/VENTouchLockPasscodeViewController.m
+++ b/VENTouchLock/Controllers/VENTouchLockPasscodeViewController.m
@@ -90,10 +90,7 @@ static const NSInteger VENTouchLockViewControllerPasscodeLength = 4;
 
 - (void)userTappedCancel
 {
-    if (self.willFinishWithResult) {
-        self.willFinishWithResult(NO);
-    }
-    [self dismissViewControllerAnimated:YES completion:nil];
+    [self finishWithResult:NO animated:YES];
 }
 
 - (void)finishWithResult:(BOOL)success animated:(BOOL)animated
@@ -102,7 +99,11 @@ static const NSInteger VENTouchLockViewControllerPasscodeLength = 4;
     if (self.willFinishWithResult) {
         self.willFinishWithResult(success);
     } else {
-        [self dismissViewControllerAnimated:animated completion:nil];
+        [self dismissViewControllerAnimated:animated completion:^{
+            if (self.didFinishWithResult) {
+                self.didFinishWithResult(success);
+            }
+        }];
     }
 }
 

--- a/VENTouchLock/Controllers/VENTouchLockSplashViewController.h
+++ b/VENTouchLock/Controllers/VENTouchLockSplashViewController.h
@@ -16,7 +16,7 @@ typedef NS_ENUM(NSUInteger, VENTouchLockSplashViewControllerUnlockType) {
  @param unlockType The type of unlock method used when unlock is successful.
  @note A secure use-case of this block is to log out of your app when success is NO.
  */
-@property (nonatomic, copy) void (^didFinishWithSuccess)(BOOL success, VENTouchLockSplashViewControllerUnlockType unlockType);
+@property (nonatomic, copy) void (^didFinishWithResult)(BOOL success, VENTouchLockSplashViewControllerUnlockType unlockType);
 
 /**
  @return A VENTouchLockSplashViewController that corresponds to the passed TouchLock.

--- a/VENTouchLock/Controllers/VENTouchLockSplashViewController.h
+++ b/VENTouchLock/Controllers/VENTouchLockSplashViewController.h
@@ -19,9 +19,11 @@ typedef NS_ENUM(NSUInteger, VENTouchLockSplashViewControllerUnlockType) {
 @property (nonatomic, copy) void (^didFinishWithSuccess)(BOOL success, VENTouchLockSplashViewControllerUnlockType unlockType);
 
 /**
- The VENTouchLock framework this class interacts with. This property should not be set outside of VENTouchLock framework's automated tests.  By default, it is set to the [VENTouchLock sharedInstance] singleton on initialization.
+ @return A VENTouchLockSplashViewController that corresponds to the passed TouchLock.
+ @note When you subclass VENTouchLockSplashViewController, you must call the super
+ implementation of this method.
  */
-@property (nonatomic, strong) VENTouchLock *touchLock;
+- (instancetype)initWithTouchLock:(VENTouchLock *)touchLock;
 
 /**
  Displays a Touch ID prompt if the device can support it.

--- a/VENTouchLock/Controllers/VENTouchLockSplashViewController.m
+++ b/VENTouchLock/Controllers/VENTouchLockSplashViewController.m
@@ -43,6 +43,11 @@
     return self;
 }
 
+- (instancetype)initWithNibName:(NSString *)nibNameOrNil bundle:(NSBundle *)nibBundleOrNil
+{
+    return [self initWithTouchLock:nil nibName:nibNameOrNil bundle:nibBundleOrNil];
+}
+
 - (void)viewDidLoad
 {
     [super viewDidLoad];

--- a/VENTouchLock/Controllers/VENTouchLockSplashViewController.m
+++ b/VENTouchLock/Controllers/VENTouchLockSplashViewController.m
@@ -11,6 +11,7 @@
 
 @implementation VENTouchLockSplashViewController
 
+
 #pragma mark - Creation and Lifecycle
 
 - (void)dealloc

--- a/VENTouchLock/Controllers/VENTouchLockSplashViewController.m
+++ b/VENTouchLock/Controllers/VENTouchLockSplashViewController.m
@@ -17,9 +17,6 @@
 - (void)dealloc
 {
     [[NSNotificationCenter defaultCenter] removeObserver:self];
-    if (!self.isSnapshotViewController) {
-        self.touchLock.backgroundLockVisible = NO;
-    }
 }
 
 - (instancetype)init
@@ -147,8 +144,8 @@
                         animated:(BOOL)animated
 {
     [self.presentingViewController dismissViewControllerAnimated:animated completion:^{
-        if (self.didFinishWithSuccess) {
-            self.didFinishWithSuccess(success, unlockType);
+        if (self.didFinishWithResult) {
+            self.didFinishWithResult(success, unlockType);
         }
     }];
 }

--- a/VENTouchLock/Controllers/VENTouchLockSplashViewController.m
+++ b/VENTouchLock/Controllers/VENTouchLockSplashViewController.m
@@ -4,8 +4,8 @@
 
 @interface VENTouchLockSplashViewController ()
 
-@property (nonatomic, assign) BOOL isSnapshotViewController;
 @property (nonatomic, strong) VENTouchLock *touchLock;
+@property (nonatomic, assign) BOOL isSnapshotViewController;
 
 @end
 
@@ -21,9 +21,21 @@
     }
 }
 
+- (instancetype)init
+{
+    return [self initWithTouchLock:nil];
+}
+
 - (instancetype)initWithTouchLock:(VENTouchLock *)touchLock
 {
-    self = [super initWithNibName:nil bundle:nil];
+    return [self initWithTouchLock:touchLock nibName:nil bundle:nil];
+}
+
+- (instancetype)initWithTouchLock:(VENTouchLock *)touchLock
+                          nibName:(NSString *)nibNameOrNil
+                           bundle:(NSBundle *)nibBundleOrNil
+{
+    self = [super initWithNibName:nibNameOrNil bundle:nibBundleOrNil];
     if (self) {
         _touchLock = touchLock ?: [VENTouchLock sharedInstance];
     }

--- a/VENTouchLock/Controllers/VENTouchLockSplashViewController.m
+++ b/VENTouchLock/Controllers/VENTouchLockSplashViewController.m
@@ -3,7 +3,10 @@
 #import "VENTouchLock.h"
 
 @interface VENTouchLockSplashViewController ()
+
 @property (nonatomic, assign) BOOL isSnapshotViewController;
+@property (nonatomic, strong) VENTouchLock *touchLock;
+
 @end
 
 @implementation VENTouchLockSplashViewController
@@ -18,29 +21,11 @@
     }
 }
 
-- (instancetype)init
+- (instancetype)initWithTouchLock:(VENTouchLock *)touchLock
 {
-    self = [super init];
+    self = [super initWithNibName:nil bundle:nil];
     if (self) {
-        [self initialize];
-    }
-    return self;
-}
-
-- (instancetype)initWithCoder:(NSCoder *)aDecoder
-{
-    self = [super initWithCoder:aDecoder];
-    if (self) {
-        [self initialize];
-    }
-    return self;
-}
-
-- (instancetype)initWithNibName:(NSString *)nibNameOrNil bundle:(NSBundle *)nibBundleOrNil
-{
-    self = [super initWithNibName:nibNameOrNil bundle:nibBundleOrNil];
-    if (self) {
-        [self initialize];
+        _touchLock = touchLock ?: [VENTouchLock sharedInstance];
     }
     return self;
 }
@@ -148,11 +133,6 @@
             self.didFinishWithSuccess(success, unlockType);
         }
     }];
-}
-
-- (void)initialize
-{
-    _touchLock = [VENTouchLock sharedInstance];
 }
 
 @end

--- a/VENTouchLock/Controllers/VENTouchLockSplashViewController.m
+++ b/VENTouchLock/Controllers/VENTouchLockSplashViewController.m
@@ -4,7 +4,7 @@
 
 @interface VENTouchLockSplashViewController ()
 
-@property (nonatomic, strong) VENTouchLock *touchLock;
+@property (nonatomic, weak) VENTouchLock *touchLock;
 @property (nonatomic, assign) BOOL isSnapshotViewController;
 
 @end

--- a/VENTouchLock/VENTouchLock.h
+++ b/VENTouchLock/VENTouchLock.h
@@ -20,6 +20,16 @@ typedef NS_ENUM(NSUInteger, VENTouchLockTouchIDResponse) {
 @property (assign, nonatomic) BOOL backgroundLockVisible;
 
 /**
+ The class of the VENTouchLockAppSwitchView subclass.
+ When the app is in the background and the TouchLock is locked, an instance of this view
+ will be added to the top of the view hieararchy and will be displayed when a user is on
+ the a multi-tasking app switch screen.
+ By default, this is NULL and there is no app switch view covering the app when the
+ TouchLock is locked.
+ */
+@property (assign, nonatomic) Class appSwitchView;
+
+/**
  The class of the VENTouchLockSplashViewController subclass.
  This view controller will be underneath the Touch ID prompt or passcode view controller.
  By default, this is NULL and there is no splash view controller when the TouchLock is locked.

--- a/VENTouchLock/VENTouchLock.h
+++ b/VENTouchLock/VENTouchLock.h
@@ -27,7 +27,7 @@ typedef NS_ENUM(NSUInteger, VENTouchLockTouchIDResponse) {
  By default, this is NULL and there is no app switch view covering the app when the
  TouchLock is locked.
  */
-@property (assign, nonatomic) Class appSwitchView;
+@property (assign, nonatomic) Class appSwitchViewClass;
 
 /**
  The class of the VENTouchLockSplashViewController subclass.

--- a/VENTouchLock/VENTouchLock.h
+++ b/VENTouchLock/VENTouchLock.h
@@ -43,13 +43,6 @@ typedef NS_ENUM(NSUInteger, VENTouchLockTouchIDResponse) {
 + (instancetype)sharedInstance;
 
 /**
- Returns a singleton TouchLock instance with a unique identifier.
- @param identifer This identifer must be unique per TouchLock instance. If nil, the identifer will default to "VENTouchLockDefaultUniqueIdentifier"
- @return A singleton TouchLock instance with the given unique identifier.
- */
-+ (instancetype)sharedInstanceWithTouchLockIdentfier:(NSString *)identifier;
-
-/**
  Set the defaults. This method should be called at launch.
  @param service The keychain service for which to set and return a passcode
  @param account The keychain account for which to set and return a passcode

--- a/VENTouchLock/VENTouchLock.h
+++ b/VENTouchLock/VENTouchLock.h
@@ -20,6 +20,14 @@ typedef NS_ENUM(NSUInteger, VENTouchLockTouchIDResponse) {
 @property (assign, nonatomic) BOOL backgroundLockVisible;
 
 /**
+ The class of the VENTouchLockSplashViewController subclass.
+ This view controller will be underneath the Touch ID prompt or passcode view controller.
+ By default, this is NULL and there is no splash view controller when the TouchLock is locked.
+ */
+@property (assign, nonatomic) Class splashViewControllerClass;
+
+
+/**
  @return A singleton TouchLock instance.
  */
 + (instancetype)sharedInstance;
@@ -42,8 +50,7 @@ typedef NS_ENUM(NSUInteger, VENTouchLockTouchIDResponse) {
    keychainPasscodeAccount:(NSString *)passcodeAccount
     keychainTouchIDAccount:(NSString *)touchIDAccount
              touchIDReason:(NSString *)reason
-      passcodeAttemptLimit:(NSUInteger)attemptLimit
- splashViewControllerClass:(Class)splashViewControllerClass;
+      passcodeAttemptLimit:(NSUInteger)attemptLimit;
 
 /**
  Returns YES if a passcode exists, and NO otherwise.

--- a/VENTouchLock/VENTouchLock.h
+++ b/VENTouchLock/VENTouchLock.h
@@ -24,8 +24,7 @@ typedef NS_ENUM(NSUInteger, VENTouchLockTouchIDResponse) {
  When the app is in the background and the TouchLock is locked, an instance of this view, that is
  the same size of the device's screen will be added to the top of the view hieararchy and
  will be displayed when a user is on the a multi-tasking app switch screen.
- By default, this is NULL and there is no app switch view covering the app when the
- TouchLock is locked.
+ By default, this is NULL and there is no app switch view covering the app when the TouchLock is locked.
  */
 @property (assign, nonatomic) Class appSwitchViewClass;
 

--- a/VENTouchLock/VENTouchLock.h
+++ b/VENTouchLock/VENTouchLock.h
@@ -17,13 +17,13 @@ typedef NS_ENUM(NSUInteger, VENTouchLockTouchIDResponse) {
 /**
  YES if the app is locked after having entered the background, and NO otherwise.
  */
-@property (assign, nonatomic) BOOL backgroundLockVisible;
+@property (assign, nonatomic, readonly) BOOL locked;
 
 /**
- The class of the VENTouchLockAppSwitchView subclass.
- When the app is in the background and the TouchLock is locked, an instance of this view
- will be added to the top of the view hieararchy and will be displayed when a user is on
- the a multi-tasking app switch screen.
+ The class of a UIView subclass.
+ When the app is in the background and the TouchLock is locked, an instance of this view, that is
+ the same size of the device's screen will be added to the top of the view hieararchy and
+ will be displayed when a user is on the a multi-tasking app switch screen.
  By default, this is NULL and there is no app switch view covering the app when the
  TouchLock is locked.
  */
@@ -35,6 +35,11 @@ typedef NS_ENUM(NSUInteger, VENTouchLockTouchIDResponse) {
  By default, this is NULL and there is no splash view controller when the TouchLock is locked.
  */
 @property (assign, nonatomic) Class splashViewControllerClass;
+
+/**
+ The proxy for the receiver's user interface. Custom appearance preferences may optionally be set by editing the returned instance's properties.
+ */
+@property (strong, nonatomic, readonly) VENTouchLockAppearance *appearance;
 
 
 /**
@@ -131,11 +136,5 @@ typedef NS_ENUM(NSUInteger, VENTouchLockTouchIDResponse) {
  Resets the incorrect password attempt count;
  */
 - (void)resetIncorrectPasscodeAttemptCount;
-
-
-/**
- @return The proxy for the receiver's user interface. Custom appearance preferences may optionally be set by editing the returned instance's properties.
- */
-- (VENTouchLockAppearance *)appearance;
 
 @end

--- a/VENTouchLock/VENTouchLock.m
+++ b/VENTouchLock/VENTouchLock.m
@@ -15,7 +15,6 @@ static NSString *const VENTouchLockTouchIDOff = @"Off";
 @property (copy, nonatomic) NSString *keychainTouchIDAccount;
 @property (copy, nonatomic) NSString *touchIDReason;
 @property (assign, nonatomic) NSUInteger passcodeAttemptLimit;
-@property (assign, nonatomic) Class splashViewControllerClass;
 @property (strong, nonatomic) UIView *snapshotView;
 @property (strong, nonatomic) VENTouchLockAppearance *appearance;
 
@@ -71,14 +70,12 @@ static NSString *const VENTouchLockTouchIDOff = @"Off";
     keychainTouchIDAccount:(NSString *)touchIDAccount
              touchIDReason:(NSString *)reason
       passcodeAttemptLimit:(NSUInteger)attemptLimit
- splashViewControllerClass:(Class)splashViewControllerClass
 {
     self.keychainService = service;
     self.keychainPasscodeAccount = passcodeAccount;
     self.keychainTouchIDAccount = touchIDAccount;
     self.touchIDReason = reason;
     self.passcodeAttemptLimit = attemptLimit;
-    self.splashViewControllerClass = splashViewControllerClass;
 }
 
 

--- a/VENTouchLock/VENTouchLock.m
+++ b/VENTouchLock/VENTouchLock.m
@@ -24,27 +24,12 @@ static NSString *const VENTouchLockTouchIDOff = @"Off";
 
 + (instancetype)sharedInstance
 {
-    return [self sharedInstanceWithTouchLockIdentfier:nil];
-}
-
-+ (instancetype)sharedInstanceWithTouchLockIdentfier:(NSString *)identifier
-{
-    static NSMutableDictionary *sharedDictionary = nil;
+    static VENTouchLock *sharedInstance = nil;
     static dispatch_once_t onceToken;
-
     dispatch_once(&onceToken, ^{
-        sharedDictionary = [[NSMutableDictionary alloc] init];
-    });
-
-    identifier = identifier ?: VENTouchLockDefaultUniqueIdentifier;
-    VENTouchLock *sharedInstance = sharedDictionary[identifier];
-
-    if (!sharedInstance) {
-        sharedInstance = [[self alloc] init];
+        sharedInstance = [[[self class] alloc] init];
         sharedInstance.appearance = [[VENTouchLockAppearance alloc] init];
-        sharedDictionary[identifier] = sharedInstance;
-    }
-
+    });
     return sharedInstance;
 }
 
@@ -203,11 +188,13 @@ static NSString *const VENTouchLockTouchIDOff = @"Off";
         return;
     }
 
+    BOOL fromBackground = [UIApplication sharedApplication].applicationState == UIApplicationStateBackground;
+    UIWindow *mainWindow = [[UIApplication sharedApplication].windows firstObject];
+    UIViewController *rootViewController = [UIViewController ventouchlock_topMostController];
+
     if (self.splashViewControllerClass != NULL) {
         VENTouchLockSplashViewController *splashViewController = [[self.splashViewControllerClass alloc] init];
         if ([splashViewController isKindOfClass:[VENTouchLockSplashViewController class]]) {
-            UIWindow *mainWindow = [[UIApplication sharedApplication].windows firstObject];
-            UIViewController *rootViewController = [UIViewController ventouchlock_topMostController];
             UIViewController *displayController;
             if (self.appearance.splashShouldEmbedInNavigationController) {
                 displayController = [splashViewController ventouchlock_embeddedInNavigationControllerWithNavigationBarClass:self.appearance.navigationBarClass];
@@ -216,7 +203,6 @@ static NSString *const VENTouchLockTouchIDOff = @"Off";
                 displayController = splashViewController;
             }
 
-            BOOL fromBackground = [UIApplication sharedApplication].applicationState == UIApplicationStateBackground;
             if (fromBackground) {
                 [[NSRunLoop currentRunLoop] runMode:NSDefaultRunLoopMode beforeDate:[NSDate dateWithTimeIntervalSinceNow:0.1]];
                 VENTouchLockSplashViewController *snapshotSplashViewController = [[self.splashViewControllerClass alloc] init];
@@ -239,6 +225,8 @@ static NSString *const VENTouchLockTouchIDOff = @"Off";
                 [rootViewController presentViewController:displayController animated:NO completion:nil];
             });
         }
+    } else {
+
     }
 }
 

--- a/VENTouchLock/VENTouchLock.m
+++ b/VENTouchLock/VENTouchLock.m
@@ -191,16 +191,16 @@ static NSString *const VENTouchLockTouchIDOff = @"Off";
     BOOL fromBackground = [UIApplication sharedApplication].applicationState == UIApplicationStateBackground;
     UIWindow *mainWindow = [[UIApplication sharedApplication].windows firstObject];
     UIViewController *rootViewController = [UIViewController ventouchlock_topMostController];
+    UIViewController *displayViewController;
 
     if (self.splashViewControllerClass != NULL) {
         VENTouchLockSplashViewController *splashViewController = [[self.splashViewControllerClass alloc] init];
         if ([splashViewController isKindOfClass:[VENTouchLockSplashViewController class]]) {
-            UIViewController *displayController;
             if (self.appearance.splashShouldEmbedInNavigationController) {
-                displayController = [splashViewController ventouchlock_embeddedInNavigationControllerWithNavigationBarClass:self.appearance.navigationBarClass];
+                displayViewController = [splashViewController ventouchlock_embeddedInNavigationControllerWithNavigationBarClass:self.appearance.navigationBarClass];
             }
             else {
-                displayController = splashViewController;
+                displayViewController = splashViewController;
             }
 
             if (fromBackground) {
@@ -220,14 +220,20 @@ static NSString *const VENTouchLockTouchIDOff = @"Off";
                 self.snapshotView = snapshotDisplayController.view;
                 [mainWindow addSubview:self.snapshotView];
             }
-            dispatch_async(dispatch_get_main_queue(), ^{
-                self.backgroundLockVisible = YES;
-                [rootViewController presentViewController:displayController animated:NO completion:nil];
-            });
         }
     } else {
-
+        VENTouchLockEnterPasscodeViewController *enterPasscodeViewController = [[VENTouchLockEnterPasscodeViewController alloc] initWithTouchLock:self];
+        if (self.appearance.passcodeViewControllerShouldEmbedInNavigationController) {
+            displayViewController = [[UINavigationController alloc] initWithRootViewController:enterPasscodeViewController];
+        } else {
+            displayViewController = enterPasscodeViewController;
+        }
     }
+
+    dispatch_async(dispatch_get_main_queue(), ^{
+        self.backgroundLockVisible = YES;
+        [rootViewController presentViewController:displayViewController animated:NO completion:nil];
+    });
 }
 
 

--- a/VENTouchLock/VENTouchLock.m
+++ b/VENTouchLock/VENTouchLock.m
@@ -201,10 +201,12 @@ static NSString *const VENTouchLockTouchIDOff = @"Off";
 
         splashViewController.didFinishWithResult = ^(BOOL success, VENTouchLockSplashViewControllerUnlockType unlockType) {
             __strong typeof(self) strongSelf = weakSelf;
-            strongSelf.locked = NO;
-            if (didFinishWithResult) {
-                didFinishWithResult(success, unlockType);
-            }
+            dispatch_async(dispatch_get_main_queue(), ^{
+                strongSelf.locked = NO;
+                if (didFinishWithResult) {
+                    didFinishWithResult(success, unlockType);
+                }
+            });
         };
 
         if ([splashViewController isKindOfClass:[VENTouchLockSplashViewController class]]) {
@@ -233,7 +235,9 @@ static NSString *const VENTouchLockTouchIDOff = @"Off";
         VENTouchLockEnterPasscodeViewController *enterPasscodeViewController = [[VENTouchLockEnterPasscodeViewController alloc] initWithTouchLock:self];
         enterPasscodeViewController.didFinishWithResult = ^(BOOL success) {
             __strong typeof(self) strongSelf = weakSelf;
-            strongSelf.locked = NO;
+            dispatch_async(dispatch_get_main_queue(), ^{
+                strongSelf.locked = NO;
+            });
         };
         if (self.appearance.passcodeViewControllerShouldEmbedInNavigationController) {
             displayViewController = [[UINavigationController alloc] initWithRootViewController:enterPasscodeViewController];

--- a/VENTouchLockSample/VENTouchLockSample/SampleAppDelegate.m
+++ b/VENTouchLockSample/VENTouchLockSample/SampleAppDelegate.m
@@ -14,8 +14,8 @@
                               keychainPasscodeAccount:@"testPasscodeAccount"
                               keychainTouchIDAccount:@"testTouchIDAccount"
                                         touchIDReason:@"Scan your fingerprint to use the app."
-                                 passcodeAttemptLimit:5
-                            splashViewControllerClass:[SampleLockSplashViewController class]];
+                                 passcodeAttemptLimit:5];
+    [VENTouchLock sharedInstance].splashViewControllerClass = [SampleLockSplashViewController class];
     return YES;
 }
 

--- a/VENTouchLockSample/VENTouchLockSample/SampleLockSplashViewController.m
+++ b/VENTouchLockSample/VENTouchLockSample/SampleLockSplashViewController.m
@@ -13,7 +13,7 @@
 {
     self = [super initWithNibName:NSStringFromClass([self class]) bundle:nil];
     if (self) {
-        self.didFinishWithSuccess = ^(BOOL success, VENTouchLockSplashViewControllerUnlockType unlockType) {
+        self.didFinishWithResult = ^(BOOL success, VENTouchLockSplashViewControllerUnlockType unlockType) {
             if (success) {
                 NSString *logString = @"Sample App Unlocked";
                 switch (unlockType) {

--- a/VENTouchLockSample/VENTouchLockSampleTests/VENTouchLockAutoLockTests.m
+++ b/VENTouchLockSample/VENTouchLockSampleTests/VENTouchLockAutoLockTests.m
@@ -7,6 +7,7 @@
 
 @property (assign, nonatomic) NSUInteger passcodeAttemptLimit;
 @property (strong, nonatomic) VENTouchLockAppearance *appearance;
+@property (assign, nonatomic, readwrite) BOOL locked;
 
 @end
 
@@ -148,7 +149,7 @@
             [splashViewController dismissWithUnlockSuccess:YES unlockType:VENTouchLockSplashViewControllerUnlockTypePasscode animated:NO];
         }
     }
-    [VENTouchLock sharedInstance].backgroundLockVisible = NO;
+    [VENTouchLock sharedInstance].locked = NO;
     [[VENTouchLock sharedInstance] deletePasscode];
 }
 

--- a/VENTouchLockTests/VENTouchLockEnterPasscodeViewControllerSpec.m
+++ b/VENTouchLockTests/VENTouchLockEnterPasscodeViewControllerSpec.m
@@ -25,8 +25,7 @@ describe(@"recordIncorrectPasscodeAttempt", ^{
               keychainPasscodeAccount:@"testPasscodeAccount"
                keychainTouchIDAccount:@"testTouchIDAccount"
                         touchIDReason:@"testReason"
-                 passcodeAttemptLimit:3
-            splashViewControllerClass:[VENTouchLockSplashViewController class]];
+                 passcodeAttemptLimit:3];
 
         VENTouchLockEnterPasscodeViewController *enterPasscodeVC = [[VENTouchLockEnterPasscodeViewController alloc] init];
         enterPasscodeVC.touchLock = touchLock;

--- a/VENTouchLockTests/VENTouchLockEnterPasscodeViewControllerSpec.m
+++ b/VENTouchLockTests/VENTouchLockEnterPasscodeViewControllerSpec.m
@@ -27,8 +27,7 @@ describe(@"recordIncorrectPasscodeAttempt", ^{
                         touchIDReason:@"testReason"
                  passcodeAttemptLimit:3];
 
-        VENTouchLockEnterPasscodeViewController *enterPasscodeVC = [[VENTouchLockEnterPasscodeViewController alloc] init];
-        enterPasscodeVC.touchLock = touchLock;
+        VENTouchLockEnterPasscodeViewController *enterPasscodeVC = [[VENTouchLockEnterPasscodeViewController alloc] initWithTouchLock:touchLock];
         mockEnterPasscodeVC = [OCMockObject partialMockForObject:enterPasscodeVC];
         [touchLock resetIncorrectPasscodeAttemptCount];
     });

--- a/VENTouchLockTests/VENTouchLockSpec.m
+++ b/VENTouchLockTests/VENTouchLockSpec.m
@@ -11,8 +11,7 @@ beforeAll(^{
           keychainPasscodeAccount:@"keychainAccount"
            keychainTouchIDAccount:@"keychainAccount"
                     touchIDReason:@"touchIDReason"
-             passcodeAttemptLimit:0
-        splashViewControllerClass:NULL];
+             passcodeAttemptLimit:0];
 });
 
 beforeEach(^{


### PR DESCRIPTION
- Removes splashVC from TouchLock setup
- creates initWithTouchLock paradigm
- Adds a `locked` readonly property
- Adds an optional snapshot view for app switch screen when splash screen is not used
- weak references to TouchLock