### PR TITLE
fix for copy error not matching other copy.

### DIFF
--- a/VENTouchLock/Models/VENTouchLockAppearance.m
+++ b/VENTouchLock/Models/VENTouchLockAppearance.m
@@ -13,7 +13,7 @@
         _cancelBarButtonItemTitle = NSLocalizedString(@"Cancel", nil);
         _createPasscodeInitialLabelText = NSLocalizedString(@"Enter a new passcode", nil);
         _createPasscodeConfirmLabelText = NSLocalizedString(@"Please re-enter your passcode", nil);
-        _createPasscodeMismatchedLabelText = NSLocalizedString(@"Passwords did not match. Try again", nil);
+        _createPasscodeMismatchedLabelText = NSLocalizedString(@"Passcodes did not match. Try again", nil);
         _createPasscodeViewControllerTitle = NSLocalizedString(@"Set Passcode", nil);
         _enterPasscodeInitialLabelText = NSLocalizedString(@"Enter your passcode", nil);
         _enterPasscodeIncorrectLabelText = NSLocalizedString(@"Incorrect passcode. Try again.", nil);


### PR DESCRIPTION
Using the word passwords instead of passcode randomly, use passcode instead.