### PR TITLE
Keychain groups support

### DIFF
--- a/VENTouchLock/VENTouchLock.h
+++ b/VENTouchLock/VENTouchLock.h
@@ -38,6 +38,22 @@ typedef NS_ENUM(NSUInteger, VENTouchLockTouchIDResponse) {
  splashViewControllerClass:(Class)splashViewControllerClass;
 
 /**
+ Set the defaults. This method should be called at launch. Access group is needed for keychain sharing.
+ @param service The keychain service for which to set and return a passcode
+ @param account The keychain account for which to set and return a passcode
+ @param accessGroup The keychain access group for which to set and return a shared passcode
+ @param splashViewControllerClass The class of the custom splash view controller. This class should be a subclass of VENTouchLockSplashViewController and any of its custom initialization must be in its init function
+ @param reason The default message displayed on the TouchID prompt
+ */
+- (void)setKeychainService:(NSString *)service
+           keychainAccount:(NSString *)account
+       keychainAccessGroup:(NSString *)accessGroup 
+             touchIDReason:(NSString *)reason
+      passcodeAttemptLimit:(NSUInteger)attemptLimit
+ splashViewControllerClass:(Class)splashViewControllerClass;
+
+
+/**
  Returns YES if a passcode exists, and NO otherwise.
  */
 - (BOOL)isPasscodeSet;

--- a/VENTouchLock/VENTouchLock.m
+++ b/VENTouchLock/VENTouchLock.m
@@ -91,6 +91,7 @@ static NSString *const VENTouchLockUserDefaultsKeyTouchIDActivated = @"VENTouchL
     query.service =  self.keychainService;
     query.account =  self.keychainAccount;
     query.accessGroup = self.keychainAccessGroup;
+    [query fetch:nil];
     return query.password;
 }
 

--- a/VENTouchLock/VENTouchLock.m
+++ b/VENTouchLock/VENTouchLock.m
@@ -10,6 +10,7 @@ static NSString *const VENTouchLockUserDefaultsKeyTouchIDActivated = @"VENTouchL
 
 @property (copy, nonatomic) NSString *keychainService;
 @property (copy, nonatomic) NSString *keychainAccount;
+@property (copy, nonatomic) NSString *keychainAccessGroup; 
 @property (copy, nonatomic) NSString *touchIDReason;
 @property (assign, nonatomic) NSUInteger passcodeAttemptLimit;
 @property (assign, nonatomic) Class splashViewControllerClass;
@@ -62,6 +63,20 @@ static NSString *const VENTouchLockUserDefaultsKeyTouchIDActivated = @"VENTouchL
     self.splashViewControllerClass = splashViewControllerClass;
 }
 
+- (void)setKeychainService:(NSString *)service
+           keychainAccount:(NSString *)account
+       keychainAccessGroup:(NSString *)accessGroup
+             touchIDReason:(NSString *)reason
+      passcodeAttemptLimit:(NSUInteger)attemptLimit
+ splashViewControllerClass:(Class)splashViewControllerClass {
+    
+    [self setKeychainService:service
+             keychainAccount:account
+               touchIDReason:reason
+        passcodeAttemptLimit:attemptLimit
+   splashViewControllerClass:splashViewControllerClass];
+    self.keychainAccessGroup = accessGroup;
+}
 
 #pragma mark - Keychain Methods
 
@@ -70,11 +85,13 @@ static NSString *const VENTouchLockUserDefaultsKeyTouchIDActivated = @"VENTouchL
     return !![self currentPasscode];
 }
 
-- (NSString *)currentPasscode
-{
-    NSString *service = self.keychainService;
-    NSString *account = self.keychainAccount;
-    return [SSKeychain passwordForService:service account:account];
+- (NSString *)currentPasscode {
+    
+    SSKeychainQuery *query = [[SSKeychainQuery alloc] init];
+    query.service =  self.keychainService;
+    query.account =  self.keychainAccount;
+    query.accessGroup = self.keychainAccessGroup;
+    return query.password;
 }
 
 - (BOOL)isPasscodeValid:(NSString *)passcode
@@ -84,9 +101,12 @@ static NSString *const VENTouchLockUserDefaultsKeyTouchIDActivated = @"VENTouchL
 
 - (void)setPasscode:(NSString *)passcode
 {
-    NSString *service = self.keychainService;
-    NSString *account = self.keychainAccount;
-    [SSKeychain setPassword:passcode forService:service account:account];
+    SSKeychainQuery *query = [[SSKeychainQuery alloc] init];
+    query.service =  self.keychainService;
+    query.account =  self.keychainAccount;
+    query.accessGroup = self.keychainAccessGroup;
+    query.password = passcode;
+    [query save:nil];
 }
 
 - (void)deletePasscode
@@ -95,9 +115,11 @@ static NSString *const VENTouchLockUserDefaultsKeyTouchIDActivated = @"VENTouchL
     [VENTouchLockEnterPasscodeViewController resetPasscodeAttemptHistory];
     [[NSUserDefaults standardUserDefaults] synchronize];
 
-    NSString *service = self.keychainService;
-    NSString *account = self.keychainAccount;
-    [SSKeychain deletePasswordForService:service account:account];
+    SSKeychainQuery *query = [[SSKeychainQuery alloc] init];
+    query.service =  self.keychainService;
+    query.account =  self.keychainAccount;
+    query.accessGroup = self.keychainAccessGroup;
+    [query deleteItem:nil];
 }
 
 

--- a/VENTouchLockTests/VENTouchLockSpec.m
+++ b/VENTouchLockTests/VENTouchLockSpec.m
@@ -98,3 +98,63 @@ describe(@"shouldUseTouchID", ^{
 });
 
 SpecEnd
+
+SpecBegin(VENTouchLockAccessGroup)
+
+beforeAll(^{
+    [[VENTouchLock sharedInstance] setKeychainService:@"keychainService"
+                                      keychainAccount:@"keychainAccount"
+                                  keychainAccessGroup:@"keychainAccessGroupAccount"
+                                        touchIDReason:@"touchIDReason"
+                                 passcodeAttemptLimit:0
+                            splashViewControllerClass:NULL];
+});
+
+beforeEach(^{
+    [[VENTouchLock sharedInstance] deletePasscode];
+});
+
+describe(@"setPasscode:", ^{
+
+    it(@"should register a passcode with VENTouchLock", ^{
+        VENTouchLock *touchLock = [VENTouchLock sharedInstance];
+        expect([touchLock isPasscodeSet]).to.equal(NO);
+        expect([touchLock currentPasscode]).to.beNil();
+
+        [[VENTouchLock sharedInstance] setPasscode:@"testPasscode"];
+
+        expect([touchLock isPasscodeSet]).to.equal(YES);
+        expect([touchLock currentPasscode]).to.equal(@"testPasscode");
+    });
+
+});
+
+describe(@"isPasscodeValid", ^{
+
+    it(@"should return YES if the parameter sent is equal to the set passcode and NO otherwise", ^{
+        VENTouchLock *touchLock = [VENTouchLock sharedInstance];
+        [touchLock setPasscode:@"testPasscode"];
+        expect([touchLock isPasscodeValid:@"testPasscode"]).to.equal(YES);
+        expect([touchLock isPasscodeValid:@"wrongPasscode"]).to.equal(NO);
+    });
+
+});
+
+describe(@"deletePasscode", ^{
+
+    it(@"should register a passcode with VENTouchLock", ^{
+        VENTouchLock *touchLock = [VENTouchLock sharedInstance];
+
+        [[VENTouchLock sharedInstance] setPasscode:@"testPasscode"];
+        expect([touchLock isPasscodeSet]).to.equal(YES);
+        expect([touchLock currentPasscode]).to.equal(@"testPasscode");
+
+        [touchLock deletePasscode];
+
+        expect([touchLock isPasscodeSet]).to.equal(NO);
+        expect([touchLock currentPasscode]).to.beNil();
+    });
+    
+});
+
+SpecEnd


### PR DESCRIPTION
I needed to support keychain groups to allow the use of this tool in an that has a Share Extension. This way both the main app and the share extension can use the same passcode. 

For this I needed to change the queries to use SSKeychainQuery's instead of the convenience methods in SSKeychain. Using this allows access to the accessGroup property which is used to specify the keychain group. 
