### PR TITLE
fix for app switcher behaviour in iOS9

### DIFF
--- a/VENTouchLock/Controllers/VENTouchLockSplashViewController.m
+++ b/VENTouchLock/Controllers/VENTouchLockSplashViewController.m
@@ -49,16 +49,16 @@
 {
     [super viewDidLoad];
     self.view.backgroundColor = [UIColor whiteColor];
-    if (!self.isSnapshotViewController) {
-        dispatch_async(dispatch_get_main_queue(), ^{
-            [self showUnlockAnimated:NO];
-        });
-    }
 }
 
 - (void)viewDidAppear:(BOOL)animated
 {
     [super viewDidAppear:animated];
+    if (!self.isSnapshotViewController) {
+        dispatch_async(dispatch_get_main_queue(), ^{
+            [self showUnlockAnimated:NO];
+        });
+    }
     [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(appWillEnterForeground) name:UIApplicationWillEnterForegroundNotification object:nil];
 }
 


### PR DESCRIPTION
These changes will fix many issues when `TouchID` is enabled.

* When going to the app switcher and closing the app (slide up)  is enabled cause the app to reopen (I guess that's because of the weird `NSRunLoop` trick).
* Sometimes when moving the app to background and back the touchID alert is not displayed until going to background and back again.