### PR TITLE
Added time frame to lock 

### DIFF
--- a/VENTouchLock/VENTouchLock.h
+++ b/VENTouchLock/VENTouchLock.h
@@ -38,6 +38,22 @@ typedef NS_ENUM(NSUInteger, VENTouchLockTouchIDResponse) {
  splashViewControllerClass:(Class)splashViewControllerClass;
 
 /**
+ Set the defaults. This method should be called at launch.
+ @param service The keychain service for which to set and return a passcode
+ @param account The keychain account for which to set and return a passcode
+ @param splashViewControllerClass The class of the custom splash view controller. This class should be a subclass of VENTouchLockSplashViewController and any of its custom initialization must be in its init function
+ @param reason The default message displayed on the TouchID prompt
+ @param secondsToLock The number of seconds from lastRefreshDate that the app will wait for lock
+ */
+- (void)setKeychainService:(NSString *)service
+           keychainAccount:(NSString *)account
+             touchIDReason:(NSString *)reason
+             secondsToLock:(NSUInteger)secondsToLock
+      passcodeAttemptLimit:(NSUInteger)attemptLimit
+ splashViewControllerClass:(Class)splashViewControllerClass;
+
+
+/**
  Returns YES if a passcode exists, and NO otherwise.
  */
 - (BOOL)isPasscodeSet;
@@ -94,6 +110,16 @@ typedef NS_ENUM(NSUInteger, VENTouchLockTouchIDResponse) {
 - (NSUInteger)passcodeAttemptLimit;
 
 /**
+ Updates de refreshDate value with current date
+ */
+- (void) updateRefreshDate;
+
+/**
+ Sets the number of seconds that the app has to wait since lastRefreshDate to lock
+ */
+- (void) setSecondsToLock:(NSUInteger) secondsToLock;
+
+/**
  If a passcode is set, calling this method will lock the app. Otherwise, calling it will not do anything.
  @note The app is automatically locked if needed (see method below) when on launch and on entering background. Use this method only if necessary in other circumstances.
  */
@@ -104,15 +130,11 @@ typedef NS_ENUM(NSUInteger, VENTouchLockTouchIDResponse) {
  */
 - (void) lockIfNeeded;
 
-
 /**
  @return The proxy for the receiver's user interface. Custom appearance preferences may optionally be set by editing the returned instance's properties.
  */
 - (VENTouchLockAppearance *)appearance;
 
-/**
-Updates de refreshDate value with current date
-*/
-- (void) updateRefreshDate;
+
 
 @end

--- a/VENTouchLock/VENTouchLock.h
+++ b/VENTouchLock/VENTouchLock.h
@@ -95,13 +95,24 @@ typedef NS_ENUM(NSUInteger, VENTouchLockTouchIDResponse) {
 
 /**
  If a passcode is set, calling this method will lock the app. Otherwise, calling it will not do anything.
- @note The app is automatically locked when on launch and on entering background. Use this method only if necessary in other circumstances.
+ @note The app is automatically locked if needed (see method below) when on launch and on entering background. Use this method only if necessary in other circumstances.
  */
 - (void)lock;
+
+/**
+  Locks the app if has passed 'secondsToLock' from 'lastRefreshDate'. Otherwile, calling it will not do anything.
+ */
+- (void) lockIfNeeded;
+
 
 /**
  @return The proxy for the receiver's user interface. Custom appearance preferences may optionally be set by editing the returned instance's properties.
  */
 - (VENTouchLockAppearance *)appearance;
+
+/**
+Updates de refreshDate value with current date
+*/
+- (void) updateRefreshDate;
 
 @end

--- a/VENTouchLock/VENTouchLock.m
+++ b/VENTouchLock/VENTouchLock.m
@@ -276,7 +276,10 @@ static NSString *const VENTouchLockUserDefaultsKeyTouchIDActivated = @"VENTouchL
         [self.snapshotView removeFromSuperview];
         self.snapshotView = nil;
     });
-
+    
+    if (!self.backgroundLockVisible) {
+        [self lockIfNeeded];
+    }
 }
 
 @end

--- a/VENTouchLock/VENTouchLock.m
+++ b/VENTouchLock/VENTouchLock.m
@@ -15,6 +15,8 @@ static NSString *const VENTouchLockUserDefaultsKeyTouchIDActivated = @"VENTouchL
 @property (assign, nonatomic) Class splashViewControllerClass;
 @property (strong, nonatomic) UIView *snapshotView;
 @property (strong, nonatomic) VENTouchLockAppearance *appearance;
+@property (nonatomic) NSInteger secondsToLock;
+@property (strong, nonatomic) NSDate* lastRefreshDate;
 
 @end
 
@@ -217,18 +219,34 @@ static NSString *const VENTouchLockUserDefaultsKeyTouchIDActivated = @"VENTouchL
     }
 }
 
+- (void) lockIfNeeded {
+    if (_lastRefreshDate) {
+        if (fabsf([_lastRefreshDate timeIntervalSinceNow]) >= _secondsToLock) {
+            [self lock];
+        }
+    } else {
+        [self lock];
+    }
+}
+
+#pragma mark - Refresh date methods
+
+- (void) updateRefreshDate {
+    _lastRefreshDate = [NSDate date];
+}
+
 
 #pragma mark - NSNotifications
 
 - (void)applicationDidFinishLaunching:(NSNotification *)notification
 {
-    [self lock];
+    [self lockIfNeeded];
 }
 
 - (void)applicationDidEnterBackground:(NSNotification *)notification
 {
     if (!self.backgroundLockVisible) {
-        [self lock];
+        [self lockIfNeeded];
     }
 }
 

--- a/VENTouchLock/VENTouchLock.m
+++ b/VENTouchLock/VENTouchLock.m
@@ -15,7 +15,7 @@ static NSString *const VENTouchLockUserDefaultsKeyTouchIDActivated = @"VENTouchL
 @property (assign, nonatomic) Class splashViewControllerClass;
 @property (strong, nonatomic) UIView *snapshotView;
 @property (strong, nonatomic) VENTouchLockAppearance *appearance;
-@property (nonatomic) NSInteger secondsToLock;
+@property (nonatomic) NSUInteger secondsToLock;
 @property (strong, nonatomic) NSDate* lastRefreshDate;
 
 @end
@@ -62,6 +62,22 @@ static NSString *const VENTouchLockUserDefaultsKeyTouchIDActivated = @"VENTouchL
     self.touchIDReason = reason;
     self.passcodeAttemptLimit = attemptLimit;
     self.splashViewControllerClass = splashViewControllerClass;
+}
+
+- (void)setKeychainService:(NSString *)service
+           keychainAccount:(NSString *)account
+             touchIDReason:(NSString *)reason
+             secondsToLock:(NSUInteger)secondsToLock
+      passcodeAttemptLimit:(NSUInteger)attemptLimit
+ splashViewControllerClass:(Class)splashViewControllerClass
+{
+    [self setKeychainService:service
+             keychainAccount:account
+               touchIDReason:reason
+        passcodeAttemptLimit:attemptLimit
+   splashViewControllerClass:splashViewControllerClass];
+    
+    self.secondsToLock = secondsToLock;
 }
 
 
@@ -233,6 +249,10 @@ static NSString *const VENTouchLockUserDefaultsKeyTouchIDActivated = @"VENTouchL
 
 - (void) updateRefreshDate {
     _lastRefreshDate = [NSDate date];
+}
+
+- (void) setSecondsToLock:(NSUInteger) secondsToLock {
+    _secondsToLock = secondsToLock;
 }
 
 


### PR DESCRIPTION
Now the library accepts one optional value: secondsToLock. This value will be used with lastRefreshDate to lock the app with lockIfNeeded. In order to refresh the lastRefreshDateValue the user has to call to updateRefreshDate method whenever he needs. The changes has been made so the previous functionality is not affected. 
